### PR TITLE
Improve spec compliance, type safety for @id fields

### DIFF
--- a/src/main/java/com/datazuul/iiif/presentation/api/ManifestGenerator.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/ManifestGenerator.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,7 +51,7 @@ import org.apache.commons.cli.ParseException;
  */
 public class ManifestGenerator {
 
-  public static void main(String[] args) throws ParseException, JsonProcessingException, IOException {
+  public static void main(String[] args) throws ParseException, JsonProcessingException, IOException, URISyntaxException {
     Options options = new Options();
     options.addOption("d", true, "Absolute file path to the directory containing the image files.");
 
@@ -104,7 +105,7 @@ public class ManifestGenerator {
   }
 
   private static void generateManifest(final String imageDirectoryName, final List<Path> files)
-          throws JsonProcessingException, IOException {
+      throws JsonProcessingException, IOException, URISyntaxException {
     // Start Manifest
     String urlPrefix = "http://www.alexandria.de/beta/demo/bookreader/";
     Manifest manifest = new Manifest(urlPrefix + imageDirectoryName + "/manifest.json", "Walters MS 168");
@@ -131,7 +132,7 @@ public class ManifestGenerator {
   }
 
   private static void addPage(String urlPrefix, String imageDirectoryName, List<Canvas> canvases, int pageCounter, Path file)
-          throws IOException {
+      throws IOException, URISyntaxException {
     Path fileName = file.getFileName();
     System.out.println(fileName.toAbsolutePath());
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/json/AbstractIiifResourceMixIn.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/json/AbstractIiifResourceMixIn.java
@@ -15,6 +15,7 @@
  */
 package com.datazuul.iiif.presentation.api.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -27,5 +28,7 @@ public abstract class AbstractIiifResourceMixIn {
     
     @JsonProperty("@type")
     abstract String getType();
-    
+
+    @JsonIgnore
+    abstract void setId(String id);
 }

--- a/src/main/java/com/datazuul/iiif/presentation/api/json/CanvasMixIn.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/json/CanvasMixIn.java
@@ -18,6 +18,8 @@ package com.datazuul.iiif.presentation.api.json;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.net.URI;
+
 /**
  *
  * @author Ralf Eichinger
@@ -25,6 +27,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public abstract class CanvasMixIn extends AbstractIiifResourceMixIn {
 
     @JsonCreator
-    CanvasMixIn(@JsonProperty("@id") String id, @JsonProperty("label") String label, @JsonProperty("height") int height, @JsonProperty("width") int width) {
+    CanvasMixIn(@JsonProperty("@id") URI id, @JsonProperty("label") String label, @JsonProperty("height") int height, @JsonProperty("width") int width) {
     }
 }

--- a/src/main/java/com/datazuul/iiif/presentation/api/json/IiifPresentationApiObjectMapper.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/json/IiifPresentationApiObjectMapper.java
@@ -3,13 +3,7 @@ package com.datazuul.iiif.presentation.api.json;
 import com.datazuul.iiif.presentation.api.model.AbstractIiifResource;
 import com.datazuul.iiif.presentation.api.model.Canvas;
 import com.datazuul.iiif.presentation.api.model.Manifest;
-import com.datazuul.iiif.presentation.api.model.other.Image;
-import com.datazuul.iiif.presentation.api.model.other.Metadata;
-import com.datazuul.iiif.presentation.api.model.other.MetadataLocalizedValue;
-import com.datazuul.iiif.presentation.api.model.other.MetadataMultilanguage;
-import com.datazuul.iiif.presentation.api.model.other.MetadataSimple;
-import com.datazuul.iiif.presentation.api.model.other.Resource;
-import com.datazuul.iiif.presentation.api.model.other.Service;
+import com.datazuul.iiif.presentation.api.model.other.*;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -31,6 +25,7 @@ public class IiifPresentationApiObjectMapper extends ObjectMapper {
     addMixIn(MetadataSimple.class, MetadataSimpleMixIn.class);
     addMixIn(Resource.class, AbstractIiifResourceMixIn.class);
     addMixIn(Service.class, ServiceMixIn.class);
+    addMixIn(Thumbnail.class, AbstractIiifResourceMixIn.class);
 
     setSerializationInclusion(JsonInclude.Include.NON_NULL);
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/json/ManifestMixIn.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/json/ManifestMixIn.java
@@ -18,6 +18,8 @@ package com.datazuul.iiif.presentation.api.json;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.net.URI;
+
 /**
  *
  * @author Ralf Eichinger
@@ -28,6 +30,6 @@ public abstract class ManifestMixIn {
     abstract String getContext();
 
     @JsonCreator
-    ManifestMixIn(@JsonProperty("@id") String id, @JsonProperty("label") String label) {
+    ManifestMixIn(@JsonProperty("@id") URI id, @JsonProperty("label") String label) {
     }
 }

--- a/src/main/java/com/datazuul/iiif/presentation/api/json/ServiceMixIn.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/json/ServiceMixIn.java
@@ -15,6 +15,7 @@
  */
 package com.datazuul.iiif.presentation.api.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -27,4 +28,7 @@ public abstract class ServiceMixIn {
     
     @JsonProperty("@id")
     abstract String getId();
+
+    @JsonIgnore
+    abstract void setId(String id);
 }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/AbstractIiifResource.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/AbstractIiifResource.java
@@ -16,7 +16,6 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Service;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -154,7 +153,6 @@ public abstract class AbstractIiifResource {
         this.id = id;
     }
 
-    @JsonIgnore
     public void setId(String id) throws URISyntaxException {
         this.id = new URI(id);
     }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/AbstractIiifResource.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/AbstractIiifResource.java
@@ -16,6 +16,10 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Service;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  *
@@ -31,7 +35,7 @@ public abstract class AbstractIiifResource {
     protected Service service; // optional
     protected String seeAlso; // optional
     protected String within; // optional
-    protected String id; // optional
+    protected URI id; // optional
 
     public String getAttribution() {
         return attribution;
@@ -142,12 +146,17 @@ public abstract class AbstractIiifResource {
         this.within = within;
     }
 
-    public String getId() {
+    public URI getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(URI id) {
         this.id = id;
+    }
+
+    @JsonIgnore
+    public void setId(String id) throws URISyntaxException {
+        this.id = new URI(id);
     }
 
 }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Annotation.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Annotation.java
@@ -16,6 +16,8 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -29,7 +31,7 @@ public class Annotation extends AbstractIiifResource {
     private String description; // optional
     private String label; // optional
     private List<Metadata> metadata; // optional
-    private String thumbnail; // optional
+    private Thumbnail thumbnail; // optional
     private String viewingHint; // optional
 
     public Annotation() {
@@ -72,11 +74,11 @@ public class Annotation extends AbstractIiifResource {
         this.metadata = metadata;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Annotation.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Annotation.java
@@ -18,6 +18,8 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -43,10 +45,14 @@ public class Annotation extends AbstractIiifResource {
      * @param id unique id of resource
      * @param label label of the Annotation
      */
-    public Annotation(String id, String label) {
+    public Annotation(URI id, String label) {
         this();
         this.label = label;
         this.id = id;
+    }
+
+    public Annotation(String id, String label) throws URISyntaxException {
+        this(new URI(id), label);
     }
     
     public String getDescription() {

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/AnnotationList.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/AnnotationList.java
@@ -16,6 +16,8 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -28,7 +30,7 @@ public class AnnotationList extends AbstractIiifResource {
     private String description; // optional
     private String label; // optional
     private List<Metadata> metadata; // optional
-    private String thumbnail; // optional
+    private Thumbnail thumbnail; // optional
     private String viewingHint; // optional
 
     public AnnotationList(String id) {
@@ -62,11 +64,11 @@ public class AnnotationList extends AbstractIiifResource {
         this.metadata = metadata;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/AnnotationList.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/AnnotationList.java
@@ -18,6 +18,8 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -33,11 +35,15 @@ public class AnnotationList extends AbstractIiifResource {
     private Thumbnail thumbnail; // optional
     private String viewingHint; // optional
 
-    public AnnotationList(String id) {
+    public AnnotationList(URI id) {
         assert id != null;
         this.id = id;
         
         type = "sc:AnnotationList";
+    }
+
+    public AnnotationList(String id) throws URISyntaxException {
+        this(new URI(id));
     }
 
     public String getDescription() {

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Canvas.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Canvas.java
@@ -19,6 +19,8 @@ import com.datazuul.iiif.presentation.api.model.other.Image;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -68,7 +70,7 @@ public class Canvas extends AbstractIiifResource {
     this.width = 0;
   }
 
-  public Canvas(String id, String label, int height, int width) {
+  public Canvas(URI id, String label, int height, int width) {
     assert id != null;
     assert label != null;
     assert height > -1;
@@ -80,6 +82,10 @@ public class Canvas extends AbstractIiifResource {
     this.width = width;
 
     type = "sc:Canvas";
+  }
+
+  public Canvas(String id, String label, int height, int width) throws URISyntaxException {
+    this(new URI(id), label, height, width);
   }
 
   /**

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Canvas.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Canvas.java
@@ -17,6 +17,8 @@ package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Image;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -44,7 +46,7 @@ public class Canvas extends AbstractIiifResource {
   private List<Image> images;
   private String label; // required
   private List<Metadata> metadata; // optional
-  private String thumbnail; // recommended
+  private Thumbnail thumbnail; // recommended
   private String viewingHint; // optional
   private int width; // required
 
@@ -95,9 +97,13 @@ public class Canvas extends AbstractIiifResource {
    * @param thumbnail A canvas may have a thumbnail and should have a thumbnail if there are multiple images or
    * resources that make up the representation.
    */
-  public Canvas(String id, String label, int height, int width, String thumbnail) {
+  public Canvas(URI id, String label, int height, int width, Thumbnail thumbnail) {
     this(id, label, height, width);
     this.thumbnail = thumbnail;
+  }
+
+  public Canvas(String id, String label, int height, int width, Thumbnail thumbnail) throws URISyntaxException {
+    this(new URI(id), label, height, width, thumbnail);
   }
 
   public String getDescription() {
@@ -138,7 +144,7 @@ public class Canvas extends AbstractIiifResource {
     this.metadata = metadata;
   }
 
-  public String getThumbnail() {
+  public Thumbnail getThumbnail() {
     return thumbnail;
   }
 
@@ -146,7 +152,7 @@ public class Canvas extends AbstractIiifResource {
    * @param thumbnail A canvas may have a thumbnail and should have a thumbnail if there are multiple images or
    * resources that make up the representation.
    */
-  public void setThumbnail(String thumbnail) {
+  public void setThumbnail(Thumbnail thumbnail) {
     this.thumbnail = thumbnail;
   }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Collection.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Collection.java
@@ -16,6 +16,8 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -29,7 +31,7 @@ public class Collection extends AbstractIiifResource {
     private String description; // recommended
     private final String label; // required
     private final List<Metadata> metadata; // recommended
-    private String thumbnail; // recommended
+    private Thumbnail thumbnail; // recommended
     private String viewingHint; // optional
 
     public Collection(String id, String label, List<Metadata> metadata) {
@@ -60,11 +62,11 @@ public class Collection extends AbstractIiifResource {
         return metadata;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Collection.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Collection.java
@@ -18,6 +18,7 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -34,7 +35,7 @@ public class Collection extends AbstractIiifResource {
     private Thumbnail thumbnail; // recommended
     private String viewingHint; // optional
 
-    public Collection(String id, String label, List<Metadata> metadata) {
+    public Collection(URI id, String label, List<Metadata> metadata) {
         assert id != null;
         assert label != null;
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Content.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Content.java
@@ -16,6 +16,8 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -32,7 +34,7 @@ public class Content extends AbstractIiifResource {
 
     protected List<Metadata> metadata; // optional
     protected String description; // optional
-    protected String thumbnail; // optional
+    protected Thumbnail thumbnail; // optional
     protected String format; // optional
     protected int height; // optional
     protected int width; // optional
@@ -69,7 +71,7 @@ public class Content extends AbstractIiifResource {
         this.description = description;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
@@ -77,7 +79,7 @@ public class Content extends AbstractIiifResource {
      * @param thumbnail A content resource may have a thumbnail and should have a thumbnail if it is an option in a
      * choice of resources.
      */
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Content.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Content.java
@@ -18,6 +18,7 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -44,7 +45,7 @@ public class Content extends AbstractIiifResource {
      * @param id A content resource must have an id unless it is embedded in the response, and it must be the http(s)
      * URI at which the resource is published.
      */
-    public Content(String id) {
+    public Content(URI id) {
         assert id != null;
         this.id = id;
     }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/ImageContent.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/ImageContent.java
@@ -15,6 +15,8 @@
  */
 package com.datazuul.iiif.presentation.api.model;
 
+import java.net.URI;
+
 /**
  * <p>
  * Recommended URI Pattern: {scheme}://{host}/{prefix}/{identifier}/annotation/{name}
@@ -26,7 +28,7 @@ public class ImageContent extends Content {
 
     private String label; // optional
 
-    public ImageContent(String id) {
+    public ImageContent(URI id) {
         super(id);
         this.type = "oa:Annotation"; // required
     }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Layer.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Layer.java
@@ -18,6 +18,7 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -35,7 +36,7 @@ public class Layer extends AbstractIiifResource {
     private String viewingDirection; // optional
     private String viewingHint; // optional
 
-    public Layer(String id, String label) {
+    public Layer(URI id, String label) {
         assert id != null;
         assert label != null;
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Layer.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Layer.java
@@ -16,6 +16,8 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -29,7 +31,7 @@ public class Layer extends AbstractIiifResource {
     private String description; // optional
     private final String label; // required
     private List<Metadata> metadata; // optional
-    private String thumbnail; // optional
+    private Thumbnail thumbnail; // optional
     private String viewingDirection; // optional
     private String viewingHint; // optional
 
@@ -63,11 +65,11 @@ public class Layer extends AbstractIiifResource {
         this.metadata = metadata;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Manifest.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Manifest.java
@@ -211,6 +211,7 @@ public class Manifest extends AbstractIiifResource {
     private final String label; // required
     private List<Metadata> metadata; // recommended
     private List<Sequence> sequences;
+    private List<Range> ranges;
     private Thumbnail thumbnail; // recommended
     private String viewingDirection; // optional
     private String viewingHint; // optional
@@ -336,5 +337,13 @@ public class Manifest extends AbstractIiifResource {
      */
     public void setViewingHint(String viewingHint) {
         this.viewingHint = viewingHint;
+    }
+
+    public List<Range> getRanges() {
+        return ranges;
+    }
+
+    public void setRanges(List<Range> ranges) {
+        this.ranges = ranges;
     }
 }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Manifest.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Manifest.java
@@ -18,6 +18,8 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 /**
@@ -213,7 +215,7 @@ public class Manifest extends AbstractIiifResource {
     private String viewingDirection; // optional
     private String viewingHint; // optional
 
-    public Manifest(String id, String label) {
+    public Manifest(URI id, String label) {
         assert id != null;
         assert label != null;
 
@@ -221,6 +223,10 @@ public class Manifest extends AbstractIiifResource {
         this.label = label;
 
         this.type = "sc:Manifest";
+    }
+
+    public Manifest(String id, String label) throws URISyntaxException {
+        this(new URI(id), label);
     }
 
     /**
@@ -257,7 +263,7 @@ public class Manifest extends AbstractIiifResource {
      * associated with it. It is recommended that a IIIF Image API service be available for this image for manipulations
      * such as resizing. A manifest should have a thumbnail image that represents the entire object or work.
      */
-    public Manifest(String id, String label, String description, List<Metadata> metadata, String thumbnail) {
+    public Manifest(URI id, String label, String description, List<Metadata> metadata, Thumbnail thumbnail) {
         this(id, label);
 
         this.description = description;

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Manifest.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Manifest.java
@@ -16,6 +16,8 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -207,7 +209,7 @@ public class Manifest extends AbstractIiifResource {
     private final String label; // required
     private List<Metadata> metadata; // recommended
     private List<Sequence> sequences;
-    private String thumbnail; // recommended
+    private Thumbnail thumbnail; // recommended
     private String viewingDirection; // optional
     private String viewingHint; // optional
 
@@ -295,11 +297,11 @@ public class Manifest extends AbstractIiifResource {
         this.sequences = sequences;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/OtherContent.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/OtherContent.java
@@ -15,6 +15,8 @@
  */
 package com.datazuul.iiif.presentation.api.model;
 
+import java.net.URI;
+
 /**
  * <p>
  * Recommended URI pattern: {scheme}://{host}/{prefix}/{identifier}/list/{name}</p>
@@ -25,7 +27,7 @@ public class OtherContent extends Content {
 
     private String label; // optional
 
-    public OtherContent(String id) {
+    public OtherContent(URI id) {
         super(id);
         this.type = "oa:Annotation";
     }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Range.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Range.java
@@ -18,6 +18,7 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -36,7 +37,7 @@ public class Range extends AbstractIiifResource {
     private String viewingDirection; // optional
     private String viewingHint; // optional
 
-    public Range(String id, String label) {
+    public Range(URI id, String label) {
         assert id != null;
         assert label != null;
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Range.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Range.java
@@ -16,6 +16,8 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
+
 import java.util.List;
 
 /**
@@ -30,7 +32,7 @@ public class Range extends AbstractIiifResource {
     private final String label; // required
     private List<Metadata> metadata; // optional
     private String startCanvas; // optional
-    private String thumbnail; // optional
+    private Thumbnail thumbnail; // optional
     private String viewingDirection; // optional
     private String viewingHint; // optional
 
@@ -79,11 +81,11 @@ public class Range extends AbstractIiifResource {
         this.startCanvas = startCanvas;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Range.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Range.java
@@ -36,6 +36,8 @@ public class Range extends AbstractIiifResource {
     private Thumbnail thumbnail; // optional
     private String viewingDirection; // optional
     private String viewingHint; // optional
+    private List<String> canvases;
+    private List<Range> ranges;
 
     public Range(URI id, String label) {
         assert id != null;
@@ -109,5 +111,21 @@ public class Range extends AbstractIiifResource {
 
     public void setViewingHint(String viewingHint) {
         this.viewingHint = viewingHint;
+    }
+
+    public List<String> getCanvases() {
+        return canvases;
+    }
+
+    public void setCanvases(List<String> canvases) {
+        this.canvases = canvases;
+    }
+
+    public List<Range> getRanges() {
+        return ranges;
+    }
+
+    public void setRanges(List<Range> ranges) {
+        this.ranges = ranges;
     }
 }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Sequence.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Sequence.java
@@ -18,6 +18,8 @@ package com.datazuul.iiif.presentation.api.model;
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
 import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 import com.datazuul.iiif.presentation.api.model.other.ViewingDirection;
+
+import java.net.URI;
 import java.util.List;
 
 /**
@@ -63,7 +65,7 @@ public class Sequence extends AbstractIiifResource {
      * @param id unique id of resource
      * @param label The label should briefly convey the nature of sequence, such as “Current Page Order”.
      */
-    public Sequence(String id, String label) {
+    public Sequence(URI id, String label) {
         this(label);
         this.id = id;
     }
@@ -91,7 +93,7 @@ public class Sequence extends AbstractIiifResource {
      * @param id A sequence may have an id.
      */
     @Override
-    public void setId(String id) {
+    public void setId(URI id) {
         this.id = id;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/Sequence.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/Sequence.java
@@ -16,6 +16,7 @@
 package com.datazuul.iiif.presentation.api.model;
 
 import com.datazuul.iiif.presentation.api.model.other.Metadata;
+import com.datazuul.iiif.presentation.api.model.other.Thumbnail;
 import com.datazuul.iiif.presentation.api.model.other.ViewingDirection;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class Sequence extends AbstractIiifResource {
     private String label; // optional
     private List<Metadata> metadata; // optional
     private String startCanvas; // optional
-    private String thumbnail; // optional
+    private Thumbnail thumbnail; // optional
     private String viewingDirection; // optional
     private String viewingHint; // optional
 
@@ -129,7 +130,7 @@ public class Sequence extends AbstractIiifResource {
         this.startCanvas = startCanvas;
     }
 
-    public String getThumbnail() {
+    public Thumbnail getThumbnail() {
         return thumbnail;
     }
 
@@ -137,7 +138,7 @@ public class Sequence extends AbstractIiifResource {
      * @param thumbnail A sequence may have a thumbnail and should have a thumbnail if there are multiple sequences in a
      * single manifest. Each of the thumbnails should be different.
      */
-    public void setThumbnail(String thumbnail) {
+    public void setThumbnail(Thumbnail thumbnail) {
         this.thumbnail = thumbnail;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Image.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Image.java
@@ -15,27 +15,34 @@
  */
 package com.datazuul.iiif.presentation.api.model.other;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  *
  * @author Ralf Eichinger
  */
 public class Image {
 
-    private String id;
+    private URI id;
     private final String motivation = "sc:painting";
     private final String type = "oa:Annotation";
-    private String on;
+    private URI on;
 
     private ImageResource resource;
 
     public Image() {
     }
 
-    public Image(String id) {
+    public Image(URI id) {
         this.id = id;
     }
 
-    public String getId() {
+    public Image(String id) throws URISyntaxException {
+        this.id = new URI(id);
+    }
+
+    public URI getId() {
         return id;
     }
 
@@ -55,11 +62,11 @@ public class Image {
         return type;
     }
 
-    public String getOn() {
+    public URI getOn() {
         return on;
     }
 
-    public void setOn(String on) {
+    public void setOn(URI on) {
         this.on = on;
     }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/ImageResource.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/ImageResource.java
@@ -15,6 +15,9 @@
  */
 package com.datazuul.iiif.presentation.api.model.other;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  *
  * @author Ralf Eichinger
@@ -28,9 +31,13 @@ public class ImageResource extends Resource {
         type = "dctypes:Image";
     }
 
-    public ImageResource(String id) {
+    public ImageResource(URI id) {
         this();
         this.id = id;
+    }
+
+    public ImageResource(String id) throws URISyntaxException {
+        this(new URI(id));
     }
 
     public int getHeight() {

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Resource.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Resource.java
@@ -15,8 +15,6 @@
  */
 package com.datazuul.iiif.presentation.api.model.other;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -49,7 +47,6 @@ public class Resource {
         this.id = id;
     }
 
-    @JsonIgnore
     public void setId(String id) throws URISyntaxException {
         this.id = new URI(id);
     }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Resource.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Resource.java
@@ -15,6 +15,11 @@
  */
 package com.datazuul.iiif.presentation.api.model.other;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  *
  * @author Ralf Eichinger
@@ -23,7 +28,7 @@ public class Resource {
     protected String format;
     // the URI at which the image can be obtained: "%3A" == ":"
     // {scheme}://{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}
-    protected String id;
+    protected URI id;
     protected String type;
     
     private Service service;
@@ -36,12 +41,17 @@ public class Resource {
         this.format = format;
     }
 
-    public String getId() {
+    public URI getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(URI id) {
         this.id = id;
+    }
+
+    @JsonIgnore
+    public void setId(String id) throws URISyntaxException {
+        this.id = new URI(id);
     }
 
     public String getType() {

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Service.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Service.java
@@ -15,6 +15,11 @@
  */
 package com.datazuul.iiif.presentation.api.model.other;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * <p>
  * A link to a service that makes more functionality available for the resource, such as from an image to the base URI
@@ -51,15 +56,19 @@ package com.datazuul.iiif.presentation.api.model.other;
 public class Service {
 
     protected String context;
-    protected String id;
+    protected URI id;
     protected String label;
     protected String profile;
 
     public Service() {
     }
 
-    public Service(String id) {
+    public Service(URI id) {
         this.id = id;
+    }
+
+    public Service(String id) throws URISyntaxException {
+        this.id = new URI(id);
     }
 
     public String getLabel() {
@@ -82,7 +91,7 @@ public class Service {
         this.context = context;
     }
 
-    public String getId() {
+    public URI getId() {
         return id;
     }
 
@@ -92,8 +101,13 @@ public class Service {
      * other than JSON-LD, or have no JSON-LD representation at all. If a IIIF Image API service is available for the
      * image, then a link to the service’s base URI should be included.
      */
-    public void setId(String id) {
+    public void setId(URI id) {
         this.id = id;
+    }
+
+    @JsonIgnore
+    public void setId(String id) throws URISyntaxException {
+        this.id = new URI(id);
     }
 
     public String getProfile() {

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Service.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Service.java
@@ -15,8 +15,6 @@
  */
 package com.datazuul.iiif.presentation.api.model.other;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -105,7 +103,6 @@ public class Service {
         this.id = id;
     }
 
-    @JsonIgnore
     public void setId(String id) throws URISyntaxException {
         this.id = new URI(id);
     }

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Thumbnail.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Thumbnail.java
@@ -1,0 +1,28 @@
+package com.datazuul.iiif.presentation.api.model.other;
+
+/**
+ * A small image that depicts or pictorially represents the resource that the property is attached to, such as the
+ * title page, a significant image or rendering of a canvas with multiple content resources associated with it.
+ * It is recommended that a IIIF Image API service be available for this image for manipulations such as resizing.
+ */
+public class Thumbnail {
+  private String id;
+  private Service service;
+
+  /** The ID should be a valid URL to an IIIF Image API endpoint that renders the thmbnail. */
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Service getService() {
+    return service;
+  }
+
+  public void setService(Service service) {
+    this.service = service;
+  }
+}

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Thumbnail.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Thumbnail.java
@@ -1,20 +1,32 @@
 package com.datazuul.iiif.presentation.api.model.other;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
 /**
  * A small image that depicts or pictorially represents the resource that the property is attached to, such as the
  * title page, a significant image or rendering of a canvas with multiple content resources associated with it.
  * It is recommended that a IIIF Image API service be available for this image for manipulations such as resizing.
  */
 public class Thumbnail {
-  private String id;
-  private Service service;
+  @JsonProperty("@id")
+  protected URI id;
+  protected Service service;
 
   /** The ID should be a valid URL to an IIIF Image API endpoint that renders the thmbnail. */
-  public void setId(String id) {
+  public void setId(URI id) {
     this.id = id;
   }
 
-  public String getId() {
+  @JsonIgnore
+  public void setId(String id) throws URISyntaxException {
+    this.id = new URI(id);
+  }
+
+  public URI getId() {
     return id;
   }
 

--- a/src/main/java/com/datazuul/iiif/presentation/api/model/other/Thumbnail.java
+++ b/src/main/java/com/datazuul/iiif/presentation/api/model/other/Thumbnail.java
@@ -1,6 +1,5 @@
 package com.datazuul.iiif.presentation.api.model.other;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.URI;
@@ -21,7 +20,6 @@ public class Thumbnail {
     this.id = id;
   }
 
-  @JsonIgnore
   public void setId(String id) throws URISyntaxException {
     this.id = new URI(id);
   }

--- a/src/test/java/com/datazuul/iiif/presentation/api/ManifestGeneratorTest.java
+++ b/src/test/java/com/datazuul/iiif/presentation/api/ManifestGeneratorTest.java
@@ -22,6 +22,9 @@ import com.datazuul.iiif.presentation.api.model.other.Image;
 import com.datazuul.iiif.presentation.api.model.other.ImageResource;
 import com.datazuul.iiif.presentation.api.model.other.Service;
 import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Assert;
@@ -37,9 +40,9 @@ public class ManifestGeneratorTest {
     }
 
     @Test
-    public void testGenerateJson() throws JsonProcessingException {
+    public void testGenerateJson() throws JsonProcessingException, URISyntaxException {
         String urlPrefix = "http://localhost:10000/de.alexandria.webapp";
-        Manifest manifest = new Manifest(urlPrefix + "/demo/bookreader/manifest.json", "Walters MS 168");
+        Manifest manifest = new Manifest(new URI(urlPrefix + "/demo/bookreader/manifest.json"), "Walters MS 168");
 
         List<Sequence> sequences = new ArrayList<>();
         manifest.setSequences(sequences);
@@ -59,9 +62,9 @@ public class ManifestGeneratorTest {
         Assert.assertTrue(json.contains("{"));
     }
 
-    private void addPage(String urlPrefix, List<Canvas> canvases) {
+    private void addPage(String urlPrefix, List<Canvas> canvases) throws URISyntaxException {
         // add a new page
-        Canvas canvas1 = new Canvas(urlPrefix + "/demo/bookreader/canvas/canvas-1", "Upper board outside", 2236, 1732);
+        Canvas canvas1 = new Canvas(new URI(urlPrefix + "/demo/bookreader/canvas/canvas-1"), "Upper board outside", 2236, 1732);
         canvases.add(canvas1);
         
         List<Image> images = new ArrayList<>();
@@ -71,7 +74,7 @@ public class ManifestGeneratorTest {
         image1.setOn(canvas1.getId());
         images.add(image1);
         
-        ImageResource imageResource1 = new ImageResource("http://stacks.stanford.edu/image/qm670kv1873/W168_000001_300");
+        ImageResource imageResource1 = new ImageResource(new URI("http://stacks.stanford.edu/image/qm670kv1873/W168_000001_300"));
         imageResource1.setHeight(2236);
         imageResource1.setWidth(1732);
         image1.setResource(imageResource1);

--- a/src/test/java/com/datazuul/iiif/presentation/api/json/JsonToManifestTest.java
+++ b/src/test/java/com/datazuul/iiif/presentation/api/json/JsonToManifestTest.java
@@ -4,6 +4,8 @@ import com.datazuul.iiif.presentation.api.model.Manifest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -30,7 +32,7 @@ public class JsonToManifestTest {
   public void testJsonToManifest() throws JsonProcessingException, IOException, URISyntaxException {
     String json = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("manifest_minimal.json"));
     Manifest manifest = objectMapper.readValue(json, Manifest.class);
-    Assert.assertTrue(manifest.getId().equals("testId"));
+    Assert.assertTrue(manifest.getId().equals(new URI("http://example.com/iiif/presentation/test-obj/manifest")));
     Assert.assertTrue(manifest.getLabel().equals("testLabel"));
     Assert.assertTrue(manifest.getType().equals("sc:Manifest"));
     Assert.assertTrue(manifest.getContext().equals("http://iiif.io/api/presentation/2/context.json"));
@@ -42,7 +44,7 @@ public class JsonToManifestTest {
   public void testJsonToMetadata() throws JsonProcessingException, IOException, URISyntaxException {
     String json = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("manifest_metadata.json"));
     Manifest manifest = objectMapper.readValue(json, Manifest.class);
-    Assert.assertTrue(manifest.getId().equals("testId"));
+    Assert.assertTrue(manifest.getId().equals(new URI("http://example.com/iiif/presentation/test-obj/manifest")));
     Assert.assertTrue(manifest.getLabel().equals("testLabel"));
     Assert.assertTrue(manifest.getType().equals("sc:Manifest"));
     Assert.assertTrue(manifest.getContext().equals("http://iiif.io/api/presentation/2/context.json"));

--- a/src/test/java/com/datazuul/iiif/presentation/api/json/JsonToManifestTest.java
+++ b/src/test/java/com/datazuul/iiif/presentation/api/json/JsonToManifestTest.java
@@ -4,6 +4,8 @@ import com.datazuul.iiif.presentation.api.model.Manifest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -25,34 +27,20 @@ public class JsonToManifestTest {
   }
 
   @Test
-  public void testJsonToManifest() throws JsonProcessingException, IOException {
-    String json = "{\"@id\":\"testId\","
-            + "\"label\":\"testLabel\","
-            + "\"@type\":\"sc:Manifest\","
-            + "\"@context\":\"http://iiif.io/api/presentation/2/context.json\"}";
+  public void testJsonToManifest() throws JsonProcessingException, IOException, URISyntaxException {
+    String json = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("manifest_minimal.json"));
     Manifest manifest = objectMapper.readValue(json, Manifest.class);
     Assert.assertTrue(manifest.getId().equals("testId"));
     Assert.assertTrue(manifest.getLabel().equals("testLabel"));
     Assert.assertTrue(manifest.getType().equals("sc:Manifest"));
     Assert.assertTrue(manifest.getContext().equals("http://iiif.io/api/presentation/2/context.json"));
+    Assert.assertEquals(manifest.getThumbnail().getId(),
+                        new URI("http://example.com/iiif/image/test-obj/full/200,/0/default.jpg"));
   }
 
   @Test
-  public void testJsonToMetadata() throws JsonProcessingException, IOException {
-    String json = "{"
-            + "\"@id\":\"testId\","
-            + "\"label\":\"testLabel\","
-            + "\"@type\":\"sc:Manifest\","
-            + "\"@context\":\"http://iiif.io/api/presentation/2/context.json\","
-            + "\"metadata\": ["
-            + "    {\"label\":\"Author\", \"value\":\"Anne Author\"},"
-            + "    {\"label\":\"Published\", \"value\": ["
-            + "        {\"@value\": \"Paris, circa 1400\", \"@language\":\"en\"},"
-            + "        {\"@value\": \"Paris, environ 14eme siecle\", \"@language\":\"fr\"}"
-            + "        ]"
-            + "    }"
-            + "  ]"
-            + "}";
+  public void testJsonToMetadata() throws JsonProcessingException, IOException, URISyntaxException {
+    String json = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("manifest_metadata.json"));
     Manifest manifest = objectMapper.readValue(json, Manifest.class);
     Assert.assertTrue(manifest.getId().equals("testId"));
     Assert.assertTrue(manifest.getLabel().equals("testLabel"));

--- a/src/test/java/com/datazuul/iiif/presentation/api/json/ManifestToJsonTest.java
+++ b/src/test/java/com/datazuul/iiif/presentation/api/json/ManifestToJsonTest.java
@@ -1,9 +1,7 @@
 package com.datazuul.iiif.presentation.api.json;
 
 import com.datazuul.iiif.presentation.api.model.Manifest;
-import com.datazuul.iiif.presentation.api.model.other.MetadataLocalizedValue;
-import com.datazuul.iiif.presentation.api.model.other.MetadataMultilanguage;
-import com.datazuul.iiif.presentation.api.model.other.MetadataSimple;
+import com.datazuul.iiif.presentation.api.model.other.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -34,6 +32,12 @@ public class ManifestToJsonTest {
   @Test
   public void testManifestToJson() throws JsonProcessingException, URISyntaxException {
     Manifest manifest = new Manifest("testId", "testLabel");
+    Thumbnail thumb = new Thumbnail();
+    thumb.setId("http://example.com/iiif/test/thumb");
+    Service service = new Service();
+    service.setId("htp://example.com/iiif/test");
+    thumb.setService(service);
+    manifest.setThumbnail(thumb);
     String json = objectMapper.writeValueAsString(manifest);
     LOGGER.debug(json);
     Assert.assertTrue(json.contains("\"@id\":\"testId\""));
@@ -65,5 +69,4 @@ public class ManifestToJsonTest {
     Assert.assertTrue(json.contains("{\"@value\":\"deutsch\",\"@language\":\"de\"}"));
     Assert.assertTrue(json.contains("{\"@value\":\"english\",\"@language\":\"en\"}"));
   }
-
 }

--- a/src/test/java/com/datazuul/iiif/presentation/api/json/ManifestToJsonTest.java
+++ b/src/test/java/com/datazuul/iiif/presentation/api/json/ManifestToJsonTest.java
@@ -6,6 +6,8 @@ import com.datazuul.iiif.presentation.api.model.other.MetadataMultilanguage;
 import com.datazuul.iiif.presentation.api.model.other.MetadataSimple;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -30,7 +32,7 @@ public class ManifestToJsonTest {
   }
 
   @Test
-  public void testManifestToJson() throws JsonProcessingException {
+  public void testManifestToJson() throws JsonProcessingException, URISyntaxException {
     Manifest manifest = new Manifest("testId", "testLabel");
     String json = objectMapper.writeValueAsString(manifest);
     LOGGER.debug(json);

--- a/src/test/resources/manifest_metadata.json
+++ b/src/test/resources/manifest_metadata.json
@@ -1,0 +1,21 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "http://example.com/iiif/presentation/test-obj/manifest",
+  "label": "testLabel",
+  "metadata": [
+    {"label": "Author", "value": "Anne Author"},
+    {"label": "Published", "value": [
+      {"@value": "Paris, circa 1400", "@language": "en"},
+      {"@value": "Paris, environ 14eme siecle", "@language": "fr"}
+    ]}
+  ],
+  "thumbnail": {
+    "@id": "http://example.com/iiif/image/test-obj/full/200,/0/default.jpg",
+    "service": {
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "http://example.com/iiif/image/test-obj",
+      "profile": "http://iiif.io/api/image/2/level1.json"
+    }
+  }
+ }

--- a/src/test/resources/manifest_minimal.json
+++ b/src/test/resources/manifest_minimal.json
@@ -1,0 +1,14 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "http://example.com/iiif/presentation/test-obj/manifest",
+  "label": "testLabel",
+  "thumbnail": {
+    "@id": "http://example.com/iiif/image/test-obj/full/200,/0/default.jpg",
+    "service": {
+      "@context": "http://iiif.io/api/image/2/context.json",
+      "@id": "http://example.com/iiif/image/test-obj",
+      "profile": "http://iiif.io/api/image/2/level1.json"
+    }
+  }
+ }


### PR DESCRIPTION
This PR implements the following changes:
- Makes the "thumbnail" field spec-compliant by using the new `Thumbnail` type instead of `String`
- Makes tthe "@id" field more typesafe and semantically clearer by using `java.net.URI` as the type and not `String`.  Overloaded methods are provided to provide some backwards-compatibility with older code (users will still have to check for `URISyntaxException`)
- Make JSON (de)serialization tests more maintainable by moving the JSON strings to their own files (avoids tedious quote-escaping).
- Add `canvases` and `ranges` fields to `Range` type
- Add `ranges` field to `Manifest` type

Sorry for not splitting these, got a bit carried away and forgot to maintain separate branches.
