### PR TITLE
Presentation API 2.1 : Adding "rendering" property to IIIF resources

### DIFF
--- a/iiif-presentation-model-api/src/main/java/de/digitalcollections/iiif/presentation/model/api/v2/IiifResource.java
+++ b/iiif-presentation-model-api/src/main/java/de/digitalcollections/iiif/presentation/model/api/v2/IiifResource.java
@@ -101,4 +101,21 @@ public interface IiifResource {
    */
   void setWithin(URI within);
 
+  List<Rendering> getRendering();
+  
+  /**
+   * @param rendering A link to an external resource intended for display or download by a human user. 
+   * This property can be used to link from a manifest, collection or other resource to the preferred viewing 
+   * environment for that resource, such as a viewer page on the publisher’s web site. 
+   *                  
+   * Other uses include a rendering of a manifest as a PDF or EPUB with the images and text of the book, 
+   * or a slide deck with images of the museum object. 
+   * 
+   * A label and the format of the rendering resource must be supplied to allow clients to present the option to the user.
+   * 
+   * Any resource type may have one or more external rendering resources.
+   */
+  void setRendering(List<Rendering> rendering);
+  
+  
 }

--- a/iiif-presentation-model-api/src/main/java/de/digitalcollections/iiif/presentation/model/api/v2/Rendering.java
+++ b/iiif-presentation-model-api/src/main/java/de/digitalcollections/iiif/presentation/model/api/v2/Rendering.java
@@ -1,0 +1,17 @@
+package de.digitalcollections.iiif.presentation.model.api.v2;
+
+import java.net.URI;
+
+public interface Rendering {
+    URI getId();
+    
+    void setId(URI id);
+
+    String getFormat();
+
+    void setFormat(String format);
+    
+    String getLabel();
+    
+    void setLabel(String label);
+}

--- a/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/jackson/mixin/v2/RenderingMixIn.java
+++ b/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/jackson/mixin/v2/RenderingMixIn.java
@@ -1,0 +1,11 @@
+package de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.digitalcollections.iiif.presentation.model.impl.v2.RenderingImpl;
+
+@JsonDeserialize(as = RenderingImpl.class)
+public abstract class RenderingMixIn {
+    @JsonProperty("@id")
+    abstract String getId();
+}

--- a/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/jackson/v2/IiifPresentationApiObjectMapper.java
+++ b/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/jackson/v2/IiifPresentationApiObjectMapper.java
@@ -22,6 +22,7 @@ import de.digitalcollections.iiif.presentation.model.api.v2.OtherContent;
 import de.digitalcollections.iiif.presentation.model.api.v2.PhysicalDimensionsService;
 import de.digitalcollections.iiif.presentation.model.api.v2.PropertyValue;
 import de.digitalcollections.iiif.presentation.model.api.v2.Range;
+import de.digitalcollections.iiif.presentation.model.api.v2.Rendering;
 import de.digitalcollections.iiif.presentation.model.api.v2.Resource;
 import de.digitalcollections.iiif.presentation.model.api.v2.SeeAlso;
 import de.digitalcollections.iiif.presentation.model.api.v2.Sequence;
@@ -52,6 +53,7 @@ import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.Other
 import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.PhysicalDimensionsMixin;
 import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.PropertyValueLocalizedMixin;
 import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.RangeMixIn;
+import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.RenderingMixIn;
 import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.ResourceMixIn;
 import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.SeeAlsoMixin;
 import de.digitalcollections.iiif.presentation.model.impl.jackson.mixin.v2.SequenceMixIn;
@@ -106,6 +108,7 @@ public class IiifPresentationApiObjectMapper extends ObjectMapper {
     addMixIn(Resource.class, ResourceMixIn.class);
     addMixIn(Sequence.class, SequenceMixIn.class);
     addMixIn(Service.class, ServiceMixIn.class);
+    addMixIn(Rendering.class, RenderingMixIn.class);
     addMixIn(Thumbnail.class, ThumbnailMixIn.class);
     addMixIn(SeeAlso.class, SeeAlsoMixin.class);
   }

--- a/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/v2/AbstractIiifResourceImpl.java
+++ b/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/v2/AbstractIiifResourceImpl.java
@@ -2,6 +2,7 @@ package de.digitalcollections.iiif.presentation.model.impl.v2;
 
 import de.digitalcollections.iiif.presentation.model.api.v2.IiifResource;
 import de.digitalcollections.iiif.presentation.model.api.v2.PropertyValue;
+import de.digitalcollections.iiif.presentation.model.api.v2.Rendering;
 import de.digitalcollections.iiif.presentation.model.api.v2.SeeAlso;
 import de.digitalcollections.iiif.presentation.model.api.v2.Service;
 import java.net.URI;
@@ -18,6 +19,7 @@ public abstract class AbstractIiifResourceImpl implements IiifResource {
   protected List<SeeAlso> seeAlso; // optional
   protected URI within; // optional
   protected URI id; // optional
+  protected List<Rendering> rendering; // optional
 
   @Override
   public PropertyValue getAttribution() {
@@ -95,6 +97,16 @@ public abstract class AbstractIiifResourceImpl implements IiifResource {
   }
 
   @Override
+  public List<Rendering> getRendering() {
+    return rendering;
+  }
+
+  @Override
+  public void setRendering(List<Rendering> rendering) {
+this.rendering = rendering;
+  }
+
+  @Override
   public URI getId() {
     return id;
   }
@@ -108,5 +120,5 @@ public abstract class AbstractIiifResourceImpl implements IiifResource {
   public void setId(String id) {
     this.id = URI.create(id);
   }
-
+  
 }

--- a/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/v2/RenderingImpl.java
+++ b/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/v2/RenderingImpl.java
@@ -1,0 +1,53 @@
+package de.digitalcollections.iiif.presentation.model.impl.v2;
+
+import de.digitalcollections.iiif.presentation.model.api.v2.Rendering;
+
+import java.net.URI;
+
+public class RenderingImpl implements Rendering {
+
+    protected URI id;
+    protected String label;
+    protected String format;
+
+    public RenderingImpl() {
+    }
+
+    public RenderingImpl(URI id) {
+        this.id = id;
+    }
+    
+    public RenderingImpl(String id) {
+        this.id = URI.create(id);
+    }
+
+    @Override
+    public URI getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(URI id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getFormat() {
+        return format;
+    }
+
+    @Override
+    public void setFormat(String format) {
+        this.format = format;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/iiif-presentation-model-impl/src/test/resources/manifest.json
+++ b/iiif-presentation-model-impl/src/test/resources/manifest.json
@@ -18,6 +18,13 @@
       "profile":"http://iiif.io/api/image/2/level1.json"
     }
   },
+  "rendering" : [{
+    "@id" : "http://some-url.org/some-id/foo.pdf",
+    "label" : "PDF (whole document)"
+  },{
+    "@id" : "http://some-url.org/some-id/foo.txt",
+    "label" : "TXT (whole document)"
+  }],
 
   "viewingDirection": "left-to-right",
   "viewingHint": "paged",


### PR DESCRIPTION
I tried to follow the same conventions as you, such as the javadoc comming from the IIIF spec.
I've also added a "rendering" example in the manifest.json used for test to assert that it does not break the mapper (although it does not assert that the content has been deserialized).

Is it fine ?

----
Related to issues : #8 & #5 