### PR TITLE
Change service deserialization to handle any service type

### DIFF
--- a/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/jackson/deserializer/v2/ServiceDeserializer.java
+++ b/iiif-presentation-model-impl/src/main/java/de/digitalcollections/iiif/presentation/model/impl/jackson/deserializer/v2/ServiceDeserializer.java
@@ -32,13 +32,12 @@ public class ServiceDeserializer extends JsonDeserializer<Service> {
     if (profileObj != null) {
       profile = ((TextNode) profileObj).textValue();
     }
-    if (profile == null || profile.contains("image")) {
-      ServiceImpl service = new ServiceImpl();
-      service.setContext(getAsString(node, "@context"));
-      service.setProfile(getAsString(node, "profile"));
-      service.setId(getAsString(node, "@id"));
-      return service;
-    } else if (profile.contains("physdim")) {
+    
+    if(profile == null) {
+      return null;
+    }
+
+    if (profile.contains("physdim")) {
       PhysicalDimensionsServiceImpl service = new PhysicalDimensionsServiceImpl();
       service.setContext(getAsString(node, "@context"));
       service.setProfile(getAsString(node, "profile"));
@@ -46,7 +45,11 @@ public class ServiceDeserializer extends JsonDeserializer<Service> {
       service.setPhysicalUnits(getAsString(node, "physicalUnits"));
       return service;
     } else {
-      return null;
+      ServiceImpl service = new ServiceImpl();
+      service.setContext(getAsString(node, "@context"));
+      service.setProfile(getAsString(node, "profile"));
+      service.setId(getAsString(node, "@id"));
+      return service;
     }
   }
 }

--- a/iiif-presentation-model-impl/src/test/java/de/digitalcollections/iiif/presentation/model/impl/jackson/IiifPresentationApiObjectMapperTest.java
+++ b/iiif-presentation-model-impl/src/test/java/de/digitalcollections/iiif/presentation/model/impl/jackson/IiifPresentationApiObjectMapperTest.java
@@ -6,35 +6,20 @@ import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
 import com.revinate.assertj.json.JsonPathAssert;
-import de.digitalcollections.iiif.presentation.model.api.v2.Canvas;
-import de.digitalcollections.iiif.presentation.model.api.v2.Collection;
-import de.digitalcollections.iiif.presentation.model.api.v2.Image;
-import de.digitalcollections.iiif.presentation.model.api.v2.ImageService;
-import de.digitalcollections.iiif.presentation.model.api.v2.Manifest;
-import de.digitalcollections.iiif.presentation.model.api.v2.Metadata;
-import de.digitalcollections.iiif.presentation.model.api.v2.PropertyValue;
-import de.digitalcollections.iiif.presentation.model.api.v2.SeeAlso;
-import de.digitalcollections.iiif.presentation.model.api.v2.Sequence;
-import de.digitalcollections.iiif.presentation.model.api.v2.Service;
-import de.digitalcollections.iiif.presentation.model.api.v2.Thumbnail;
+import de.digitalcollections.iiif.presentation.model.api.v2.*;
 import de.digitalcollections.iiif.presentation.model.api.v2.references.CollectionReference;
 import de.digitalcollections.iiif.presentation.model.api.v2.references.ManifestReference;
 import de.digitalcollections.iiif.presentation.model.impl.jackson.v2.IiifPresentationApiObjectMapper;
-import de.digitalcollections.iiif.presentation.model.impl.v2.CanvasImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.CollectionImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ImageImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ImageResourceImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ImageServiceImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ManifestImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.MetadataImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.PhysicalDimensionsServiceImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.PropertyValueLocalizedImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.PropertyValueSimpleImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.SeeAlsoImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ServiceImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ThumbnailImpl;
+import de.digitalcollections.iiif.presentation.model.impl.v2.*;
 import de.digitalcollections.iiif.presentation.model.impl.v2.references.CollectionReferenceImpl;
 import de.digitalcollections.iiif.presentation.model.impl.v2.references.ManifestReferenceImpl;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
@@ -45,14 +30,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import org.apache.commons.io.IOUtils;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class IiifPresentationApiObjectMapperTest {
 
@@ -125,8 +105,9 @@ public class IiifPresentationApiObjectMapperTest {
     Assert.assertEquals("Umschlag vorne", firstCanvasLabel.getValues(Locale.GERMAN).get(0));
     Assert.assertEquals("Front Cover", firstCanvasLabel.getValues(Locale.ENGLISH).get(0));
     Assert.assertEquals("Umschlag vorne", firstCanvasLabel.getValues().get(0));
+    Assert.assertEquals("http://some-url.org/some-search-api", manifest.getServices().get(0).getId().toString());
   }
-
+  
   @Test
   public void testManifestToJson() throws JsonProcessingException {
     Manifest manifest = new ManifestImpl("testId", new PropertyValueSimpleImpl("testLabel"));

--- a/iiif-presentation-model-impl/src/test/resources/manifest.json
+++ b/iiif-presentation-model-impl/src/test/resources/manifest.json
@@ -3,6 +3,12 @@
   "@id":"http://www.alexandria.de/iiif/presentation/alx%3AHJDHSKDHDJSDSDHKJSHKD/manifest",
   "@type":"sc:Manifest",
 
+  "service" : [ {
+    "profile" : "http://iiif.io/api/search/0/search",
+    "@context" : "http://iiif.io/api/search/0/context.json",
+    "@id" : "http://some-url.org/some-search-api"
+  } ],
+
   "label": "Die Mechanik der festen, flüssigen und gasförmigen Körper; 1. Teil; Die Mechanik der festen Körper",
   "metadata": [
     {"label":"Author", "value":"Albrecht von Ihering"},


### PR DESCRIPTION
Hello,

I am trying to add a search api service but the deserialization of the manifests for services was only processing "image" and "physdim" cases.
As the image part of the deserialization did not had anything special, I transformed it into a more generic case.

What do you think about it ?